### PR TITLE
support anti-clockwise arcs

### DIFF
--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -230,7 +230,7 @@ exports.closePath = function(ctx) {
 exports.arc = function(ctx) {
     return function(a) {
         return function() {
-            ctx.arc(a.x, a.y, a.r, a.start, a.end);
+            ctx.arc(a.x, a.y, a.r, a.start, a.end, a.clockwise);
         };
     };
 };

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -418,6 +418,7 @@ type Arc =
   , r :: Number
   , start :: Number
   , end   :: Number
+  , anti :: Boolean
   }
 
 -- | Render an arc object.


### PR DESCRIPTION
Some time ago I posted an RFC of sorts (in issue #57) that didn't get any comments.  This patch adds support for anti-clockwise arcs very trivially by making an optional parameter mandatory, which is not backwards compatible.

Obviously this isn't a perfect approach but I don't really have the time to design a general system for optional parameters.  One easy possibility is to just add a second function which takes a different number of arguments, but that would not align exactly with the JS specification.