### PR TITLE
Change field names of Transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 - Migrate FFI to ES modules (#85 by @JordanMartinez)
 - Support arcs that are drawn counter-clockwise (#58, #83 by @karljs and @JordanMartinez)
+- The `Transform` type now uses the field names `a`, `b`, `c`, `d`, `e` and `f`, instead of `m11`, `m12`, `m21`, `m22`, `m31` and `m32` (#86 by @artemisSystem)
 
 New features:
 - Added `createImageDataWith` (#81)

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -291,7 +291,7 @@ export function translate(ctx) {
 export function transform(ctx) {
   return function(t) {
     return function() {
-      ctx.transform(t.m11, t.m12, t.m21, t.m22, t.m31, t.m32);
+      ctx.transform(t.a, t.b, t.c, t.d, t.e, t.f);
     };
   };
 }
@@ -299,7 +299,7 @@ export function transform(ctx) {
 export function setTransform(ctx) {
   return function(t) {
     return function() {
-      ctx.setTransform(t.m11, t.m12, t.m21, t.m22, t.m31, t.m32);
+      ctx.setTransform(t.a, t.b, t.c, t.d, t.e, t.f);
     };
   };
 }

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -479,12 +479,12 @@ foreign import translate :: Context2D -> TranslateTransform -> Effect Unit
 
 -- | An object representing a general transformation as a homogeneous matrix.
 type Transform =
-  { m11 :: Number
-  , m12 :: Number
-  , m21 :: Number
-  , m22 :: Number
-  , m31 :: Number
-  , m32 :: Number
+  { a :: Number
+  , b :: Number
+  , c :: Number
+  , d :: Number
+  , e :: Number
+  , f :: Number
   }
 
 -- | Apply a general transformation to the current transformation matrix


### PR DESCRIPTION
**Description of the change**

Change the field names of `Transform` to be `a`, `b`, `c`, `d`, `e` and `f`, instead of `m11`, `m12`, `m21`, `m22`, `m31` and `m32`.
---

Closes #72 

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- ~~Updated or added relevant documentation~~
- ~~Added a test for the contribution (if applicable)~~ (Project has no tests)
